### PR TITLE
Fix assert when removing columns.

### DIFF
--- a/src/qmlmodels/qqmltreemodeltotablemodel.cpp
+++ b/src/qmlmodels/qqmltreemodeltotablemodel.cpp
@@ -982,14 +982,12 @@ void QQmlTreeModelToTableModel::modelRowsMoved(const QModelIndex & sourceParent,
 
 void QQmlTreeModelToTableModel::modelColumnsAboutToBeInserted(const QModelIndex & parent, int start, int end)
 {
-    Q_UNUSED(parent);
-    beginInsertColumns({}, start, end);
+    beginInsertColumns(parent, start, end);
 }
 
 void QQmlTreeModelToTableModel::modelColumnsAboutToBeRemoved(const QModelIndex & parent, int start, int end)
 {
-    Q_UNUSED(parent);
-    beginRemoveColumns({}, start, end);
+    beginRemoveColumns(parent, start, end);
 }
 
 void QQmlTreeModelToTableModel::modelColumnsInserted(const QModelIndex & parent, int start, int end)


### PR DESCRIPTION
QSortFilterProxyModelPrivate::filter_changed() calls handle_filter_changed for all children whenever columns get removed.

Since QTBUG-94100 fix (4f1c1ba238e382697cee636bb544e92532d9ba51), QQmlTreeModelToTableModel::modelColumnsAboutToBeRemoved is trying to do beginRemoveColumn() multiple time on the root index, because it ignore 'parent' (which would be different for each child). That trigger an assert on the root index.

Solution: don't ignore parent argument and call it on the correct node.

refs RM-65464

Change-Id: I0d483a6ba1088d5ae9a01c960089dd05791dd155