### PR TITLE
Make Qmllint error on warnings again.

### DIFF
--- a/tools/qmllint/main.cpp
+++ b/tools/qmllint/main.cpp
@@ -198,7 +198,7 @@ All warnings can be set to three levels:
             );
     parser.addOption(maxWarnings);
     const QString maxWarningsSetting = QLatin1String("MaxWarnings");
-    settings.addOption(maxWarningsSetting, -1);
+    settings.addOption(maxWarningsSetting, 0);
 
     auto addCategory = [&](const QQmlJS::LoggerCategory &category) {
         categories.push_back(category);
@@ -433,7 +433,7 @@ All warnings can be set to three levels:
         {
             int value = parser.isSet(maxWarnings) ? parser.value(maxWarnings).toInt()
                                                   : settings.value(maxWarningsSetting).toInt();
-            if (value != -1 && value < linter.logger()->warnings().size())
+            if (value != -1 && linter.logger() && value < linter.logger()->warnings().size())
                 success = false;
         }
 


### PR DESCRIPTION
Built qmllint from sources with default max-warnings default value to 0 then replaced the resulted executable and pdf file.

Remake of qt:qt|r3077

refs RM-69184 RM-64508

Change-Id: I9091803f52493f9e0d9d33eae45a90bdfa627690